### PR TITLE
Revert "Update mlflow version to 3.10.1 in requirements.txt"

### DIFF
--- a/mlflow/requirements.txt
+++ b/mlflow/requirements.txt
@@ -1,4 +1,4 @@
 cryptography==44.0.3 # TODO: Check if this is needed
 boto3==1.37.30 # Used because MinIO provides an S3-compatible API
-mlflow==3.10.1
+mlflow==3.4.0
 psycopg2-binary==2.9.10 # Added based on the existing command in mlflow.yaml


### PR DESCRIPTION
Reverts qubernetes-dev/images#10

The mlflow version 3.10 have some breaking changes compared to version 3.4 which does not work with existing qluster configurrations. Either qluster or image need to be changed in order to make things work properly. So I am reverting this version increase change back to previous version which work properly with existing qluster configuration